### PR TITLE
ci: add "All checks passed" aggregate gate

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -314,3 +314,21 @@ jobs:
       - name: e2e tests
         run: |
           tox -e e2e-py${{ matrix.python-version }}-linux
+
+  all_checks_passed:
+    name: All checks passed
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_doc_check
+      - linter_checks
+      - scan
+    steps:
+      - name: Verify all required jobs succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || \
+                "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a single `all_checks_passed` meta job to `main_workflow.yml` that depends on all currently-mandatory jobs (`lock_check`, `copyright_and_doc_check`, `linter_checks`, `scan`), runs with `if: always()`, and fails if any dependency failed or was cancelled.
- Intended to be the sole required status check on `main` so that adding/removing mandatory jobs is a workflow edit instead of a branch-protection change.
- `test` and `e2e-tests` are excluded because they are currently `continue-on-error: True` (and `e2e-tests` is `if: false`). Promote them into the `needs:` list if/when they should block merges.

## Test plan
- [ ] CI runs on this PR and the new `All checks passed` job appears and succeeds once its `needs` deps finish
- [ ] After merge, add `All checks passed` (strict) as the only required status check on `main` branch protection